### PR TITLE
Correct the issues_url in the metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "summary": "A module that will download files for use on Windows servers. Requires the server to have PowerShell 2.0 and above",
   "source": "https://github.com/voxpupuli/puppet-download_file",
   "project_page": "https://github.com/voxpupuli/puppet-download_file",
-  "issues_url": "https://github.com/puppet-voxpupuli/puppet-download_file/issues",
+  "issues_url": "https://github.com/voxpupuli/puppet-download_file/issues",
   "tags": ["windows", "utility"],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This link generated in the Forge uses this, which results in a broken link. Reported by @alexpilotti via email
